### PR TITLE
Added docker support for containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM gradle:7.6.0-jdk17 as BUILDER
+COPY . .
+RUN gradle installBootDist
+EXPOSE 8082
+EXPOSE 80
+RUN chmod +x start.sh
+CMD ["./start.sh"]
+
+# eventually get this to work for smaller image
+#FROM amazoncorretto:11
+#COPY --from=BUILDER /build/install/csw9-boot .
+#EXPOSE 80
+#CMD ["./csw9-boot/bin/csw9"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+java -jar h2-1.4.190.jar &
+sleep 5
+build/install/csw9-boot/bin/csw9


### PR DESCRIPTION
Added Dockerfile for building a docker image for the website. Dockerfile runs the h2 database as well as the website. Also added start.sh containing the startup procedure for the project, used by the docker container and the ide.
Dockerfile needs work, but functions at the moment.